### PR TITLE
build(deps): bump nginxinc/nginx-unprivileged from 1.21-alpine to 1.25-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginxinc/nginx-unprivileged:1.21-alpine
+FROM nginxinc/nginx-unprivileged:1.25-alpine
 COPY index.html /usr/share/nginx/html/index.html
 COPY content /usr/share/nginx/html/content
 COPY nginx/nginx.conf /etc/nginx/


### PR DESCRIPTION
Bumping base image to the latest and greatest.